### PR TITLE
Replace gmail with outlook for nodemailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ By default the `production.js` script is loaded. Any changes made to the codebas
 
 *Note:* This requires the setting up of a [Firebase project](https://firebase.google.com/) (hosting and functions), which is not covered here. If you want to host someplace else or simply want to test locally, it's best to use the alternative method below.
 
-*Note:* In order for the contact form to work, a dedicated Gmail account will be required to route queries posted via the form to you and to the sender. When setting up the email account, both [less secure apps](https://myaccount.google.com/lesssecureapps) and [display unlock captcha](https://accounts.google.com/DisplayUnlockCaptcha) need to be enabled for Nodemailer not to be blocked by Google.
+*Note:* In order for the contact form to work, a dedicated Outlook account will be required to route queries posted via the form to you and to the sender.
 
 
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Move up to the main directory again and run the `serve` script. This starts both
 
 After the project has been set up, the `dev` script can be run to save time. This executes the `babel`, `watchify` and `serve` scripts simultaneously. It is the only command that needs to be run before developing locally.
 
-### `npm run deploy-all` (hosted only)
+### `npm run deploy` (hosted only)
 
-Deploy both Firebase hosting and Firebase functions from the root directory. In future, these can be deployed separately as required. Run `npm deploy` from this main directory for hosting or the same script from the `functions` directory to deploy functions.
+Deploy both Firebase hosting and Firebase functions from the root directory.
 
 
 --------------------------------

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,7 +9,7 @@
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "firebase-admin": "^9.2.0",
-        "firebase-functions": "^3.16.0",
+        "firebase-functions": "^3.24.0",
         "isomorphic-fetch": "^3.0.0",
         "nodemailer": "^6.7.8"
       },
@@ -872,21 +872,25 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.16.0.tgz",
-      "integrity": "sha512-6ISOn0JckMtpA3aJ/+wCCGhThUhBUrpZD+tSkUeolx0Vr+NoYFXA0+2YzJZa/A2MDU8gotPzUtnauLSEQvfClQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.0.tgz",
+      "integrity": "sha512-YKZm/AxjnWTP9VbxAyjs7ImWfMydleQAiHB2T6li3imRCcwC4+h6BXU/Jf2uELz9AkCb+UabWbdVrklk3b+70Q==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.14",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0"
+        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/firebase-functions-test": {
@@ -2757,15 +2761,16 @@
       }
     },
     "firebase-functions": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.16.0.tgz",
-      "integrity": "sha512-6ISOn0JckMtpA3aJ/+wCCGhThUhBUrpZD+tSkUeolx0Vr+NoYFXA0+2YzJZa/A2MDU8gotPzUtnauLSEQvfClQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.0.tgz",
+      "integrity": "sha512-YKZm/AxjnWTP9VbxAyjs7ImWfMydleQAiHB2T6li3imRCcwC4+h6BXU/Jf2uELz9AkCb+UabWbdVrklk3b+70Q==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.14",
+        "node-fetch": "^2.6.7"
       }
     },
     "firebase-functions-test": {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,7 +11,7 @@
         "firebase-admin": "^9.2.0",
         "firebase-functions": "^3.16.0",
         "isomorphic-fetch": "^3.0.0",
-        "nodemailer": "^6.6.1"
+        "nodemailer": "^6.7.8"
       },
       "devDependencies": {
         "firebase-functions-test": "^0.2.0"
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.1.tgz",
-      "integrity": "sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg==",
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.8.tgz",
+      "integrity": "sha512-2zaTFGqZixVmTxpJRCFC+Vk5eGRd/fYtvIR+dl5u9QXLTQWGIf48x/JXvo58g9sa0bU6To04XUv554Paykum3g==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3224,9 +3224,9 @@
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "nodemailer": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.1.tgz",
-      "integrity": "sha512-1xzFN3gqv+/qJ6YRyxBxfTYstLNt0FCtZaFRvf4Sg9wxNGWbwFmGXVpfSi6ThGK6aRxAo+KjHtYSW8NvCsNSAg=="
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.8.tgz",
+      "integrity": "sha512-2zaTFGqZixVmTxpJRCFC+Vk5eGRd/fYtvIR+dl5u9QXLTQWGIf48x/JXvo58g9sa0bU6To04XUv554Paykum3g=="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "firebase-admin": "^9.2.0",
-    "firebase-functions": "^3.16.0",
+    "firebase-functions": "^3.24.0",
     "isomorphic-fetch": "^3.0.0",
     "nodemailer": "^6.7.8"
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,7 @@
     "firebase-admin": "^9.2.0",
     "firebase-functions": "^3.16.0",
     "isomorphic-fetch": "^3.0.0",
-    "nodemailer": "^6.6.1"
+    "nodemailer": "^6.7.8"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"

--- a/functions/routes/email.js
+++ b/functions/routes/email.js
@@ -16,6 +16,7 @@ router.post("/submit", async (req, res) => {
 
   const myEmail = {
     to: "lucasoconnell4@gmail.com",
+    from: functions.config().email_router.email,
     subject: `A new message from ${req.body.name}`,
     text: `${req.body.name} sent the following message:
           \n\n ${req.body.message}
@@ -24,6 +25,7 @@ router.post("/submit", async (req, res) => {
 
   const sendersEmail = {
     to: req.body.email,
+    from: functions.config().email_router.email,
     subject: "A copy of your message to Lucas",
     text: `You just sent Lucas the following message:\n\n${req.body.message}`
   };

--- a/functions/routes/email.js
+++ b/functions/routes/email.js
@@ -7,7 +7,7 @@ const router = express.Router();
 router.post("/submit", async (req, res) => {
   // Set Nodemailer configuration, auth and email details.
   const transporter = nodemailer.createTransport({
-    service: "gmail",
+    service: "outlook",
     auth: {
       user: functions.config().email_router.email,
       pass: functions.config().email_router.password


### PR DESCRIPTION
Gmail is no longer suitable for sending emails via `nodemailer`. They have [discontinued](https://support.google.com/accounts/answer/6010255?hl=en) the provision of Less Secure Apps (i.e. Apps that only require an email and password to access). This means it's very difficult to send emails using Gmail now (it may be possible via OAuth).

Outlook was selected as a replacement. With some minor tweaks, it now does the job that Gmail once did - send emails containing the form info to me and the person that filled out the form.