### PR TITLE
Update recaptcha keys

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -26,6 +26,7 @@ const secrets = {
    secrets: [
      "EMAIL_ADDRESS",
      "EMAIL_PASSWORD",
+     "RECAPTCHA_SECRET",
    ],
  };
 

--- a/functions/routes/email.js
+++ b/functions/routes/email.js
@@ -34,7 +34,7 @@ router.post("/submit", async (req, res) => {
 
   // Call reCaptcha api to verify user.
   const responseKey = req.body["g-recaptcha-response"];
-  const secretKey = "6LfeSREdAAAAANliAluUdtgpT2V5CkVhGddr5xxQ";
+  const secretKey = process.env.RECAPTCHA_SECRET;
   const baseUrl = "https://www.google.com/recaptcha/api/siteverify";
   const params = `?secret=${secretKey}&response=${responseKey}`;
 

--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
           <input id="email" class="contact-user" type="text" placeholder="Email" name="email" /><br>
           <textarea id="message" class="contact-message" placeholder="Message" name="message"></textarea><br>
           <div class="g-recaptcha"
-               data-sitekey="6LfeSREdAAAAAGO14nqrqWFxEc03lAq47TbrNgL6"
+               data-sitekey="6LcIoi4iAAAAANcHgBNgcGOt2TToLM3gOqvV8021"
                data-callback="correctCaptcha"
                data-expired-callback="expiredCaptcha">
           </div>


### PR DESCRIPTION
The reCAPTCHA site settings were deleted and then re-created as it wasn't possible to roll the keys. This produced new keys, of which the secret one was stored via Firebase secret manager with the shell command `firebase functions:secrets:set RECAPTCHA_SECRET`.